### PR TITLE
Link README titles to their articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,22 @@ This repository contains essays that discuss recent debates in artificial intell
 ### 1. [Debunking AI Hype](https://github.com/Glushiator/stuff/blob/main/Debunking%20AI%20Hype%20by%20Claude%20Opus.md)
 - **`Debunking AI Hype by Claude Opus.md`** – An article summarizing Dr. Emmanuel Jewelry's critical view of the current AI landscape, emphasizing the industry disconnect between hype and reality.
 
-### 2. The Theory That Shatters Language Itself
+### 2. [The Theory That Shatters Language Itself](https://github.com/Glushiator/stuff/blob/main/The%20Theory%20That%20Shatters%20Language%20Itself%20by%20Claude%20Opus.md)
 - **`The Theory That Shatters Language Itself by Claude Opus.md`** – An exploration of Professor Elan Barenholtz's ideas about language models and meaning, written in the voice of "Claude Opus."
 
-### 3. Unifying Consciousness, Computation, and Language
+### 3. [Unifying Consciousness, Computation, and Language](https://github.com/Glushiator/stuff/blob/main/Unifying%20Consciousness%2C%20Computation%2C%20and%20Language%3A%20A%20Conversation%20on%20the%20Frontiers%20of%20Mind%20and%20Machine%20by%20Claude%20Opus%204.1.md)
 - **`Unifying Consciousness, Computation, and Language: A Conversation on the Frontiers of Mind and Machine by Claude Opus 4.1.md`** – A summary of a conversation at the MIT Media Lab that bridges philosophical views on consciousness with insights from computation and language models.
 
-### 4. The Million Dollar Challenge
+### 4. [The Million Dollar Challenge](https://github.com/Glushiator/stuff/blob/main/The%20Million%20Dollar%20Challenge%3A%20Why%20AI%20Can%27t%20Solve%20Simple%20Puzzles%20That%20Children%20Can%20by%20Claude%20Opus%204.1.md)
 - **`The Million Dollar Challenge: Why AI Can't Solve Simple Puzzles That Children Can by Claude Opus 4.1.md`** – A discussion of François Chollet's ARC benchmark and its role in highlighting the gap between human reasoning and current AI capabilities.
 
-### 5. Why the "Godfather of AI" Now Fears His Own Creation
+### 5. [Why the "Godfather of AI" Now Fears His Own Creation](https://github.com/Glushiator/stuff/blob/main/Why%20The%20%22Godfather%20of%20AI%22%20Now%20Fears%20His%20Own%20Creation%20%7C%20Geoffrey%20Hinton%20by%20Opus%20Sonnet%204.md)
 - **`Why The "Godfather of AI" Now Fears His Own Creation | Geoffrey Hinton by Opus Sonnet 4.md`** – A reflection on Geoffrey Hinton's warning about AI's rapid progress and the risks of misaligned systems.
 
-### 6. The Era of Experience: David Silver on AI's Next Frontier Beyond Human Data
+### 6. [The Era of Experience: David Silver on AI's Next Frontier Beyond Human Data](https://github.com/Glushiator/stuff/blob/main/The%20Era%20of%20Experience%3A%20David%20Silver%20on%20AI%27s%20Next%20Frontier%20Beyond%20Human%20Data%20by%20Claude%20Opus%204.1.md)
 - **`The Era of Experience: David Silver on AI's Next Frontier Beyond Human Data by Claude Opus 4.1.md`** – David Silver argues for moving beyond human data, calling for AI that learns through its own experience to uncover insights humans haven't yet discovered.
 
-### 7. AI Editor Prompt
+### 7. [AI Editor Prompt](https://github.com/Glushiator/stuff/blob/main/AI%20EDITOR%20PROMPT.md)
 - **`AI EDITOR PROMPT.md`** – A structured prompt outlining guidelines for converting raw transcripts into polished, reference-ready articles.
 
 All pieces link to their source material and represent interpretations rather than official transcripts. Feel free to read, learn, or adapt them for your own work.


### PR DESCRIPTION
## Summary
- link remaining README article titles to their corresponding markdown files

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7969628c832f8b6c269f45d205d3